### PR TITLE
[KED-3046] Remove "QuantumBlack Labs" from places where it doesn't belong any more

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 This repo contains links to articles, podcasts and videos about Kedro, as well as community created examples of Kedro projects. 
 
 
-[![GitHub Discussions](https://img.shields.io/github/discussions/quantumblacklabs/kedro?logo=GitHub)](https://github.com/quantumblacklabs/kedro/discussions) [![Discord](https://img.shields.io/discord/778216384475693066?color=57c&logo=discord)](https://discord.com/invite/akJDeVaxnB)
+[![GitHub Discussions](https://img.shields.io/github/discussions/kedro-org/kedro?logo=GitHub)](https://github.com/kedro-org/kedro/discussions) [![Discord](https://img.shields.io/discord/778216384475693066?color=57c&logo=discord)](https://discord.com/invite/akJDeVaxnB)
 
-If you're looking to engage with the community then we suggest checking our [Discord server](https://discord.com/invite/akJDeVaxnB) or [GitHub discussions](https://github.com/quantumblacklabs/kedro/discussions). 
+If you're looking to engage with the community then we suggest checking our [Discord server](https://discord.com/invite/akJDeVaxnB) or [GitHub discussions](https://github.com/kedro-org/kedro/discussions). 
 
 ## Become a Kedroid <img src="./artwork/kedroid.png" width="25" >
 
@@ -21,15 +21,15 @@ This is our affectionate term for power users and people who really help out oth
 
 |Date|Deck|Recording|
 |---|---|---|
-|June 2020|[Link](https://quantumblacklabs.github.io/kedro-community/)|[YouTube link](https://youtu.be/fULOrO-QpsE)|
+|June 2020|[Link](https://github.com/kedro-org/kedro-community)|[YouTube link](https://youtu.be/fULOrO-QpsE)|
 
 
 ## Where can I find more example projects using Kedro?
 
 The Kedro team maintains the following official Kedro tutorial projects, also known as starters:
-- [Spaceflights tutorial](https://github.com/quantumblacklabs/kedro-starter-spaceflights)
-- [Iris dataset tutorial with pandas](https://github.com/quantumblacklabs/kedro-starter-pandas-iris)
-- [Iris dataset tutorial with pyspark](https://github.com/quantumblacklabs/kedro-starter-pyspark-iris)
+- [Spaceflights tutorial](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights)
+- [Iris dataset tutorial with pandas](https://github.com/kedro-org/kedro-starters/tree/main/pandas-iris)
+- [Iris dataset tutorial with pyspark](https://github.com/kedro-org/kedro-starters/tree/main/pyspark)
 
 Our community of Kedro users are creating their own profile projects, you can have a look at:
 
@@ -118,4 +118,4 @@ The community of plugin authors tag each project on GitHub with the [`kedro-plug
 
 ## What licence do you use?
 
-Kedro is licensed under the [Apache 2.0](https://github.com/quantumblacklabs/kedro-example/blob/master/LICENSE.md) License.
+Kedro is licensed under the [Apache 2.0](https://github.com/kedro-org/kedro/blob/main/LICENSE.md) License.

--- a/showcases/2021-06/components/Socials.vue
+++ b/showcases/2021-06/components/Socials.vue
@@ -17,7 +17,7 @@
       <carbon-logo-discord />
     </a>
     <a
-      href="https://github.com/quantumblacklabs/kedro"
+      href="https://github.com/kedro-org/kedro"
       target="_blank"
       alt="GitHub"
       class="icon-btn opacity-80 rounded-full !border-none !hover:text-white"
@@ -29,7 +29,7 @@
   <span abs class="m-1 abs-bl">
     <div class="inline">
         <a
-          href="https://github.com/quantumblacklabs/kedro"
+          href="https://github.com/kedro-org/kedro"
           target="_blank"
           alt="Kedro Retro June 2021"
           class="icon-btn rounded-full opacity-100 !border-none"

--- a/showcases/2021-06/slides.md
+++ b/showcases/2021-06/slides.md
@@ -26,7 +26,7 @@ theme: apple-basic
 class: text-left
 highlighter: shiki
 layout: iframe-right
-url: https://quantumblacklabs.github.io/kedro-viz
+url: https://github.com/kedro-org/kedro-viz
 ---
 
 # Today's agenda
@@ -156,7 +156,7 @@ url: https://kedro.readthedocs.io/en/stable/10_deployment/01_deployment_guide.ht
 <Socials />
 ---
 layout: iframe-right
-url: https://quantumblacklabs.github.io/kedro-viz
+url: https://github.com/kedro-org/kedro-viz
 ---
 <Overview />
 <Pointer class="absolute bottom-16"/>
@@ -391,7 +391,7 @@ layout: quote
 
 # 💅 Kedro Viz: Not just a pretty face
 
-Also - we've just posted this [neat guide](https://github.com/quantumblacklabs/kedro-viz/blob/main/LAYOUT_ENGINE.md)  to how our layout engine works
+Also - we've just posted this [neat guide](https://github.com/kedro-org/kedro-viz/blob/main/LAYOUT_ENGINE.md)  to how our layout engine works
 <div abs class=" abs-tr mr-25 mt-45">
 <img src="/showtime.gif" class="rounded rounded-lg shadow-lg h-50"/>
 </div>


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
There's a few mentions that kedro is authored by QuantumBlack Labs (e.g. in kedro docs, setup.,py, `kedro info`). Following the migration to LF these shouldn't be there any more.

Best way to find them is just to search "quantumblack" in the codebase - there's not that many results to check through.

Additionally you will also have to update URLs for Kedro-Airflow, Kedro-Docker and Kedro-Telemetry as they have completely changed repo location.

As well as kedro repository, you should check kedro-community, kedro-plugins, kedro-viz and kedro-training. kedro-starters has already been updated.

https://jira.quantumblack.com/browse/KED-3046

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Assigned myself to the PR
- [ ] Added tests to cover my changes
